### PR TITLE
ci: enable dependabot and use maven

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-- package-ecosystem: gomod
+- package-ecosystem: maven
   directory: "/dependabot"
   schedule:
     interval: daily

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.github.remiheens</groupId>
+    <artifactId>mattermost-docker-arm</artifactId>
+    <version>0.0.0-SNAPSHOT</version>
+    <properties>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.tests.skip>true</maven.tests.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+    <repositories>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+    </repositories>
+    <dependencies>
+        <dependency>
+            <groupId>com.github.mattermost</groupId>
+            <artifactId>mattermost</artifactId>
+            <version>9.1.1</version>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
I create a pom.xml file to manage update from github release with jitpack.io