### PR TITLE
Automatically set volume permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,21 +23,6 @@ You just have to update ’dependabot/go.mod’ and ’.github/workflows/release
 1. Up the stack ’docker-compose up -d’
 1. Go to http://localhost:8000
 
-## Troubleshootings
-
-```
-app_1  | No configuration file /mattermost/config/config.json
-app_1  | Creating a new one
-app_1  | cp: can't create '/mattermost/config/config.json': Permission denied
-app_1  | /entrypoint.sh: line 44: can't create /mattermost/config/config.json.tmp: Permission denied
-```
-
-Workaround :
-```
-sudo chown -R $(id -u):$(id -g) ./volumes
-docker-compose up --force-recreate
-```
-
 # Credits 
 
 Original repository for source code : https://github.com/SmartHoneybee/ubiquitous-memory

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -37,11 +37,10 @@ RUN mkdir -p /mattermost/data /mattermost/plugins /mattermost/client/plugins \
         && chown -R mattermost:mattermost /mattermost/config.json.save /mattermost/plugins /mattermost/client/plugins \
         && setcap cap_net_bind_service=+ep /mattermost/bin/mattermost
 
-USER mattermost
-
 # Configure entrypoint and command
+COPY priv-entrypoint.sh /
 COPY entrypoint.sh /
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/priv-entrypoint.sh"]
 
 WORKDIR /mattermost
 CMD ["mattermost"]

--- a/app/priv-entrypoint.sh
+++ b/app/priv-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+for folder in "/mattermost/data" "/mattermost/logs" "/mattermost/config" "/mattermost/plugins" "/mattermost/client/plugins"; do
+    echo Fixing permissions on $folder
+    chown mattermost:mattermost $folder
+done
+
+echo Dropping root and running mattermost entrypoint
+su mattermost -c "/entrypoint.sh $@"


### PR DESCRIPTION
Run the app container as root to start and correct the volume permissions before dropping privileges to the mattermost user and running the original entrypoint script.

This worked for me, open to feedback if you'd like to tweak it or try another approach.