### PR TITLE
Fix docker-compose.yaml.local args

### DIFF
--- a/docker-compose.yml.local
+++ b/docker-compose.yml.local
@@ -17,8 +17,8 @@ services:
       context: app
       args:
         - MM_VERSION=v9.4.1
-        - GOOS=linux
-        - GOARCH=arm64
+        - TARGETOS=linux
+        - TARGETARCH=arm64
     restart: unless-stopped
     volumes:
       - ./volumes/app/mattermost/config:/mattermost/config:rw


### PR DESCRIPTION
The Dockerfile for app expects TARGETOS and TARGETARCH not GOOS and GOARCH.

I'm not 100% sure if I'm missing something or not here, bu I needed this modification for things to work. I thought I'd open a PR and we can have a discussion in the comments if I'm off base.