### PR TITLE
fix(ci): fix `check-mattermost.yml`

### DIFF
--- a/.github/workflows/check-mattermost.yml
+++ b/.github/workflows/check-mattermost.yml
@@ -30,7 +30,7 @@ jobs:
 
         if [ "${{ steps.get_release.outputs.latest_release }}" != "$MATTERMOST_VERSION" ]; then
           echo "New release detected"
-          sed -i "s/MATTERMOST_VERSION=(.*)/MATTERMOST_VERSION=${{ steps.get_release.outputs.latest_release }}/" mattermost-release.txt
+          sed -i "s/MATTERMOST_VERSION=\(.*\)/MATTERMOST_VERSION=${{ steps.get_release.outputs.latest_release }}/" mattermost-release.txt
           echo "::set-output name=new_release::true"
           if [[ "${{ steps.get_release.outputs.latest_release }}" =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
             major="${BASH_REMATCH[1]}"


### PR DESCRIPTION
1. The current `sed` command in the check-mattermost.yml workflow does not correctly update the `MATTERMOST_VERSION` in the `mattermost-release.txt` file, as the regular expression `(.*)` is not being interpreted correctly. A proper escape of the parentheses fixes the issue. 
  ```sh
  sed -i "s/MATTERMOST_VERSION=\(.*\)/MATTERMOST_VERSION=${{ steps.get_release.outputs.latest_release }}/" mattermost-release.txt
  ```
2. The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
  ```sh
  # echo "::set-output name=latest_release::$latest_release"  # deprecated 
  echo "LATEST_RELEASE=$latest_release" >> $GITHUB_ENV
  ```
3.Per [Common Issue - Create using an existing branch as the PR branch](https://github.com/peter-evans/create-pull-request/blob/main/docs/common-issues.md#create-using-an-existing-branch-as-the-pr-branch), change PR action to use the official GitHub CLI. 