### PR TITLE
fix(ci): update `check-mattermost.yml`

### DIFF
--- a/.github/workflows/check-mattermost.yml
+++ b/.github/workflows/check-mattermost.yml
@@ -29,15 +29,26 @@ jobs:
         echo "Latest release: ${{ env.LATEST_RELEASE }}"
 
         if [ "${{ env.LATEST_RELEASE }}" != "$MATTERMOST_VERSION" ]; then
-          echo "New release detected"
-          sed -i "s/MATTERMOST_VERSION=\(.*\)/MATTERMOST_VERSION=${{ env.LATEST_RELEASE }}/" mattermost-release.txt
-          echo "NEW_RELEASE=true" >> $GITHUB_ENV
           if [[ "${{ env.LATEST_RELEASE }}" =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
             major="${BASH_REMATCH[1]}"
             minor="${BASH_REMATCH[2]}"
             patch="${BASH_REMATCH[3]}"
+  
+            echo "New release detected"
+
+            # If branch exists, do nothing
+            if git ls-remote --heads origin | grep -q "upgrade-$major.$minor"; then
+              echo "Branch upgrade-$major.$minor already exists"
+              echo "NEW_RELEASE=false" >> $GITHUB_ENV
+              exit 0
+            fi
+
+            # Branch DNE, update MATTERMOST_VERSION
+            sed -i "s/MATTERMOST_VERSION=\(.*\)/MATTERMOST_VERSION=${{ env.LATEST_RELEASE }}/" mattermost-release.txt
+
+            echo "BRANCH_NAME=upgrade-$major.$minor" >> $GITHUB_ENV
+            echo "NEW_RELEASE=true" >> $GITHUB_ENV
           fi
-          echo "BRANCH_NAME=upgrade-to-${major}.${minor}" >> $GITHUB_ENV
         else
           echo "No new release"
           echo "NEW_RELEASE=false" >> $GITHUB_ENV

--- a/.github/workflows/check-mattermost.yml
+++ b/.github/workflows/check-mattermost.yml
@@ -54,15 +54,19 @@ jobs:
         git commit -m "chore: Upgrade to ${{ env.LATEST_RELEASE }}"
         git push origin ${{ env.BRANCH_NAME }}
 
-    - name: Create Pull Request
+    - name: Create pull request via GitHub CLI
       if: env.NEW_RELEASE == 'true'
-      uses: peter-evans/create-pull-request@v6
-      with:
-        token: ${{ secrets.GH_TOKEN }}
-        commit-message: "chore: Upgrade to ${{ env.LATEST_RELEASE }}"
-        branch: ${{ env.BRANCH_NAME }}
-        title: Update files for new mattermost release ${{ env.LATEST_RELEASE }}
-        labels: auto-upgrade
-        delete-branch: true
-        reviewers: remiheens
-        assignees: remiheens
+      env:
+        GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      run: |
+        gh label list | grep -q auto-upgrade || gh label create auto-upgrade \
+          -c FABC7B \
+          -d "Pull requests that upgrade mattermost version automatically"
+        gh pr create \
+          --assignee @me \
+          --base main \
+          --body "" \
+          --head ${{ env.BRANCH_NAME }} \
+          --label auto-upgrade \
+          --reviewer remiheens \
+          --title "Update files for new mattermost release ${{ env.LATEST_RELEASE }}"

--- a/.github/workflows/check-mattermost.yml
+++ b/.github/workflows/check-mattermost.yml
@@ -30,7 +30,7 @@ jobs:
 
         if [ "${{ steps.get_release.outputs.latest_release }}" != "$MATTERMOST_VERSION" ]; then
           echo "New release detected"
-          sed -i "s/MATTERMOST_VERSION=(.*)/MATTERMOST_VERSION=${{ steps.get_release.outputs.latest_release }}/" mattermost-release.txt
+          sed -i "s/MATTERMOST_VERSION=\(.*\)/MATTERMOST_VERSION=${{ steps.get_release.outputs.latest_release }}/" mattermost-release.txt
           echo "::set-output name=new_release::true"
           if [[ "${{ steps.get_release.outputs.latest_release }}" =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
             major="${BASH_REMATCH[1]}"

--- a/.github/workflows/check-mattermost.yml
+++ b/.github/workflows/check-mattermost.yml
@@ -16,7 +16,7 @@ jobs:
       id: get_release
       run: |
         latest_release=$(curl -s https://api.github.com/repos/mattermost/mattermost/releases/latest | jq -r .tag_name)
-        echo "::set-output name=latest_release::$latest_release"
+        echo "LATEST_RELEASE=$latest_release" >> $GITHUB_ENV
 
     - name: Compare with last known release
       id: compare_release
@@ -26,42 +26,42 @@ jobs:
         set +o allexport
 
         echo "Last known release: $MATTERMOST_VERSION"
-        echo "Latest release: ${{ steps.get_release.outputs.latest_release }}"
+        echo "Latest release: ${{ env.LATEST_RELEASE }}"
 
-        if [ "${{ steps.get_release.outputs.latest_release }}" != "$MATTERMOST_VERSION" ]; then
+        if [ "${{ env.LATEST_RELEASE }}" != "$MATTERMOST_VERSION" ]; then
           echo "New release detected"
-          sed -i "s/MATTERMOST_VERSION=\(.*\)/MATTERMOST_VERSION=${{ steps.get_release.outputs.latest_release }}/" mattermost-release.txt
-          echo "::set-output name=new_release::true"
-          if [[ "${{ steps.get_release.outputs.latest_release }}" =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+          sed -i "s/MATTERMOST_VERSION=\(.*\)/MATTERMOST_VERSION=${{ env.LATEST_RELEASE }}/" mattermost-release.txt
+          echo "NEW_RELEASE=true" >> $GITHUB_ENV
+          if [[ "${{ env.LATEST_RELEASE }}" =~ v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
             major="${BASH_REMATCH[1]}"
             minor="${BASH_REMATCH[2]}"
             patch="${BASH_REMATCH[3]}"
           fi
-          echo "::set-output name=branch_name::upgrade-$major.$minor"
+          echo "BRANCH_NAME=upgrade-to-${major}.${minor}" >> $GITHUB_ENV
         else
           echo "No new release"
-          echo "::set-output name=new_release::false"
+          echo "NEW_RELEASE=false" >> $GITHUB_ENV
         fi
 
     - name: Create or update mattermost-release.txt
       id: set_branch_for_upgrade
-      if: steps.compare_release.outputs.new_release == 'true'
+      if: env.NEW_RELEASE == 'true'
       run: |
         git config --global user.name 'github-actions'
         git config --global user.email 'github-actions@github.com'
-        git checkout -b ${{ steps.compare_release.outputs.branch_name }} || git checkout ${{ steps.compare_release.outputs.branch_name }}
+        git checkout -b ${{ env.BRANCH_NAME }} || git checkout ${{ env.BRANCH_NAME }}
         git add mattermost-release.txt
-        git commit -m "chore: Upgrade to ${{ steps.get_release.outputs.latest_release }}"
-        git push origin ${{ steps.compare_release.outputs.branch_name }}      
+        git commit -m "chore: Upgrade to ${{ env.LATEST_RELEASE }}"
+        git push origin ${{ env.BRANCH_NAME }}
 
     - name: Create Pull Request
-      if: steps.compare_release.outputs.new_release == 'true'
+      if: env.NEW_RELEASE == 'true'
       uses: peter-evans/create-pull-request@v6
       with:
         token: ${{ secrets.GH_TOKEN }}
-        commit-message: "chore: Upgrade to ${{ steps.get_release.outputs.latest_release }}"
-        branch: ${{ steps.set_branch_for_upgrade.outputs.branch_name }}
-        title: Update files for new mattermost release ${{ steps.get_release.outputs.latest_release }}
+        commit-message: "chore: Upgrade to ${{ env.LATEST_RELEASE }}"
+        branch: ${{ env.BRANCH_NAME }}
+        title: Update files for new mattermost release ${{ env.LATEST_RELEASE }}
         labels: auto-upgrade
         delete-branch: true
         reviewers: remiheens


### PR DESCRIPTION
1. The current `sed` command in the check-mattermost.yml workflow does not correctly update the `MATTERMOST_VERSION` in the `mattermost-release.txt` file, as the regular expression `(.*)` is not being interpreted correctly. A proper escape of the parentheses fixes the issue. 
  ```sh
  sed -i "s/MATTERMOST_VERSION=\(.*\)/MATTERMOST_VERSION=${{ steps.get_release.outputs.latest_release }}/" mattermost-release.txt
  ```
2. The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
  ```sh
  # echo "::set-output name=latest_release::$latest_release"  # deprecated 
  echo "LATEST_RELEASE=$latest_release" >> $GITHUB_ENV
  ```
3.Per [Common Issue - Create using an existing branch as the PR branch](https://github.com/peter-evans/create-pull-request/blob/main/docs/common-issues.md#create-using-an-existing-branch-as-the-pr-branch), change PR action to use the official GitHub CLI. 