### PR TITLE
update volume path for postgres18 breaking change

### DIFF
--- a/docker-compose.yml.local
+++ b/docker-compose.yml.local
@@ -2,21 +2,21 @@ version: "3"
 
 services:
   db:
-    image: rheens/mattermost-db:v9.8.1
+    image: rheens/mattermost-db:v11.1.0
     build:
       context: db
     restart: unless-stopped
     volumes:
-      - ./volumes/db/var/lib/postgresql/data:/var/lib/postgresql/data
+      - ./volumes/db/var/lib/postgresql:/var/lib/postgresql
       - /etc/localtime:/etc/localtime:ro
     env_file:
       - run.env
   app:
-    image: rheens/mattermost-app:v9.8.1
+    image: rheens/mattermost-app:v11.1.0
     build:
       context: app
       args:
-        - MM_VERSION=v9.8.1
+        - MM_VERSION=v11.1.0
         - GOOS=linux
         - GOARCH=arm64
     restart: unless-stopped


### PR DESCRIPTION
The upstream Postgres version 18 container made a breaking change around the path of the data volume path. This updates the path in the example `docker-compose.yml` to match the new upstream one.

Note that exsiting installations would need manual intervnetion to migrate to the new path as well as migrate the database from 17 to 18 (Postgres doesn't support dtabase binary compatibliity between major versions).

This also bumps the example `docker-compose.yml` to the newest avaliable version of this repo's Mattermost images.

see: https://github.com/docker-library/postgres/commit/b9a533c87bdd767c228bf4c7490f9a6437a7d9f3